### PR TITLE
feat(env): ajoute la configuration S3 aux fichiers templates

### DIFF
--- a/src/environments/environment.development.template.ts
+++ b/src/environments/environment.development.template.ts
@@ -1,4 +1,8 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:3000',
+  s3: {
+    enabled: true,
+    baseUrl: 'https://s3.djoudj.dev/arcadia'
+  }
 };

--- a/src/environments/environment.prod.template.ts
+++ b/src/environments/environment.prod.template.ts
@@ -1,4 +1,8 @@
 export const environment = {
   production: true,
   apiUrl: 'https://arcadia-api.nedellec-julien.fr',
+  s3: {
+    enabled: true,
+    baseUrl: 'https://s3.djoudj.dev/arcadia'
+  }
 };

--- a/src/environments/environment.template.ts
+++ b/src/environments/environment.template.ts
@@ -1,4 +1,8 @@
 export const environment = {
   production: false,
   apiUrl: 'http://localhost:3000',
+  s3: {
+    enabled: true,
+    baseUrl: 'https://s3.djoudj.dev/arcadia'
+  }
 };


### PR DESCRIPTION
- Ajoute un objet `s3` contenant les clés `enabled` et `baseUrl` aux templates d'environnement (dev, prod, template)
- Facilite la prise en charge des ressources hébergées sur S3